### PR TITLE
rename shard size fields for compatibility

### DIFF
--- a/src/components/UsagePromptCard.vue
+++ b/src/components/UsagePromptCard.vue
@@ -34,8 +34,8 @@
               <small v-if="!canBeStarted" class="text-muted">
                 <br>
                 <b-icon-exclamation-triangle-fill variant="warning"></b-icon-exclamation-triangle-fill>
-                Starting the app requires a Shard of size <b>{{ app.minimum_shard_size | uppercase }}</b> or larger -
-                Current size: <b>{{ $store.state.profile.shard_size | uppercase }}</b>
+                Starting the app requires a Shard of size <b>{{ app.minimum_portal_size | uppercase }}</b> or larger -
+                Current size: <b>{{ $store.state.profile.vm_size | uppercase }}</b>
               </small>
             </p>
           </b-card-text>
@@ -59,8 +59,8 @@ export default {
     canBeStarted() {
       const sizes = ['xs', 's', 'm', 'l', 'xl'];
       if (this.$store.state.profile) {
-        const currentSize = sizes.indexOf(this.$store.state.profile.shard_size);
-        const requiredSize = sizes.indexOf(this.app.minimum_shard_size);
+        const currentSize = sizes.indexOf(this.$store.state.profile.vm_size);
+        const requiredSize = sizes.indexOf(this.app.minimum_portal_size);
         return currentSize >= requiredSize;
       } else {
         return true;

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -355,14 +355,14 @@ export default {
       }
     },
     sizeIsAvailable(size) {
-      if (this.$store.state.profile.max_shard_size === undefined) {
+      if (this.$store.state.profile.max_vm_size === undefined) {
         return false;
       }
-      return this.resize.sizes.indexOf(size) <= this.resize.sizes.indexOf(this.$store.state.profile.max_shard_size)
-          && size !== this.$store.state.profile.shard_size;
+      return this.resize.sizes.indexOf(size) <= this.resize.sizes.indexOf(this.$store.state.profile.max_vm_size)
+          && size !== this.$store.state.profile.vm_size;
     },
     variantForSize(size) {
-      if (size === this.$store.state.profile.shard_size) {
+      if (size === this.$store.state.profile.vm_size) {
         return 'info';
       } else if (size === this.resize.selectedSize) {
         return 'primary';


### PR DESCRIPTION
The profile endpoint calls them vm_size and max_vm_size. The app_meta.json still calls it max_portal_size.