### PR TITLE
Fix #14: Display the connection interrupted sign only after some time of interruption

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -7,7 +7,7 @@
         <ShardIdBadge :shard-id="$store.getters.short_shard_id"/>
       </b-navbar-brand>
 
-      <b-navbar-nav v-if="!$store.state.websocket.isConnected" id="nav-ws-warning">
+      <b-navbar-nav v-if="showConnectionWarning" id="nav-ws-warning">
         <b-nav-item>
           <b-icon-exclamation-triangle-fill
               variant="warning"
@@ -170,6 +170,7 @@ export default {
 
   data() {
     return {
+      now: Date.now(),
       feedback: {
         text: '',
         isSending: false,
@@ -179,7 +180,20 @@ export default {
     }
   },
 
+  created() {
+    this._nowInterval = setInterval(() => { this.now = Date.now(); }, 1000);
+  },
+
+  beforeDestroy() {
+    clearInterval(this._nowInterval);
+  },
+
   computed: {
+    showConnectionWarning() {
+      const disconnectedSince = this.$store.state.websocket.disconnectedSince;
+      return disconnectedSince !== null && (this.now - disconnectedSince) >= 5000;
+    },
+
     uiUpdateMessage() {
       if (this.$store.state.version !== null && this.$store.state.version !== pjson.version) {
         return `Refresh to update to ${this.$store.state.version}`;

--- a/src/store.js
+++ b/src/store.js
@@ -7,7 +7,7 @@ Vue.use(Vuex)
 const store = new Vuex.Store({
     state: {
         websocket: {
-            isConnected: false,
+            disconnectedSince: null,
             lastHeartbeat: null,
         },
         meta: {
@@ -60,10 +60,10 @@ const store = new Vuex.Store({
             state.tours = tours;
         },
         websocket_connect(state) {
-            state.websocket.isConnected = true;
+            state.websocket.disconnectedSince = null;
         },
         websocket_disconnect(state) {
-            state.websocket.isConnected = false;
+            state.websocket.disconnectedSince = Date.now();
         },
         set_apps(state, apps) {
             state.apps = apps;


### PR DESCRIPTION
Closes #14

Replaced the `isConnected` boolean in the Vuex store with a `disconnectedSince` timestamp (null when connected, a `Date.now()` timestamp when disconnected). In `Navbar.vue`, added a 1-second reactive ticker (`now`) and a `showConnectionWarning` computed property that only returns true when `disconnectedSince` is non-null and at least 5000 ms have elapsed — hiding the connection warning on initial load and tolerating brief interruptions.