### PR TITLE
Fix resize endpoint URL and request body field

### DIFF
--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -372,7 +372,7 @@ export default {
     },
     async resizeShard() {
       this.resize.waitingForRestart = true;
-      await this.$http.post('/core/protected/management/resize', {size: this.resize.selectedSize});
+      await this.$http.post('/core/protected/management/api/shards/self/resize', {new_vm_size: this.resize.selectedSize});
       await this.$router.replace('/restart');
     }
   },


### PR DESCRIPTION
## Summary
- Fixes `resizeShard()` in `Settings.vue` to call the correct controller endpoint `/core/protected/management/api/shards/self/resize` (was `/core/protected/management/resize`)
- Updates the request body field from `size` to `new_vm_size` to match the controller's `ResizeRequest` model

Depends on freeshard-controller#160 being deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)