### PR TITLE
Handle resize API errors in Settings.vue

### DIFF
--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -372,8 +372,14 @@ export default {
     },
     async resizeShard() {
       this.resize.waitingForRestart = true;
-      await this.$http.post('/core/protected/management/api/shards/self/resize', {new_vm_size: this.resize.selectedSize});
-      await this.$router.replace('/restart');
+      try {
+        await this.$http.post('/core/protected/management/api/shards/self/resize', {new_vm_size: this.resize.selectedSize});
+        await this.$router.replace('/restart');
+      } catch (e) {
+        this.toastError('Error during resize', e.response.data.detail);
+      } finally {
+        this.resize.waitingForRestart = false;
+      }
     }
   },
 


### PR DESCRIPTION
## Summary

- `resizeShard()` had no try-catch, so any API error (e.g. the 404 from an invalid resize) left `resize.waitingForRestart = true` permanently, keeping the Apply button disabled and showing no feedback to the user
- Added try-catch-finally following the same pattern used by all other async methods in `Settings.vue`: show a toast on error, reset the waiting flag in `finally`

## Test plan

- [ ] Trigger a resize error (e.g. by resizing to the current size via the API directly) — a toast with the error detail should appear and the Apply button should re-enable
- [ ] Successful resize still navigates to `/restart` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)