### PR TITLE
Fix #18: The connection interrupted sign appears intermittently when connection is gone continuously

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -170,7 +170,7 @@ export default {
 
   data() {
     return {
-      now: Date.now(),
+      warningEnabled: false,
       feedback: {
         text: '',
         isSending: false,
@@ -181,17 +181,17 @@ export default {
   },
 
   created() {
-    this._nowInterval = setInterval(() => { this.now = Date.now(); }, 1000);
+    this._warningTimeout = setTimeout(() => { this.warningEnabled = true; }, 5000);
   },
 
   beforeDestroy() {
-    clearInterval(this._nowInterval);
+    clearTimeout(this._warningTimeout);
   },
 
   computed: {
     showConnectionWarning() {
       const disconnectedSince = this.$store.state.websocket.disconnectedSince;
-      return disconnectedSince !== null && (this.now - disconnectedSince) >= 5000;
+      return this.warningEnabled && disconnectedSince !== null;
     },
 
     uiUpdateMessage() {


### PR DESCRIPTION
Closes #18

Fixed the intermittent connection warning in Navbar.vue by replacing the rolling 5-second threshold (which caused flickering during reconnect attempts) with a `warningEnabled` flag initialized to `false` and set to `true` after a 5-second timeout on `created()`. The `showConnectionWarning` computed property now returns `this.warningEnabled && disconnectedSince !== null`, so the warning is suppressed only during the initial 5-second page load window, then shows immediately and stays visible for any disconnect thereafter.