### PR TITLE
fix(settings): align subscription card with the controller contract

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -24,6 +24,7 @@ Vue.prototype.$http = axios.create({
 });
 
 Vue.filter('uppercase', function (value) {
+  if (value === undefined || value === null) return value;
   return value.toUpperCase();
 });
 

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -63,11 +63,11 @@
               <!-- Active / Active+pending -->
               <template v-else-if="subscriptionState === 'active' || subscriptionState === 'active-pending'">
                 <b-card-text>
-                  Plan: <b>{{ $store.state.profile.subscription.vm_size | uppercase }}</b>
+                  Plan: <b>{{ $store.state.profile.vm_size | uppercase }}</b>
                   — {{ formatPrice(centsToEur($store.state.profile.subscription.price_cents)) }}/month
                 </b-card-text>
-                <b-card-text v-if="$store.state.profile.subscription.next_charge_at">
-                  Next charge {{ $store.state.profile.subscription.next_charge_at | formatDateHumanize }}.
+                <b-card-text v-if="$store.state.profile.subscription.next_billing_date">
+                  Next charge {{ $store.state.profile.subscription.next_billing_date | formatDateHumanize }}.
                 </b-card-text>
                 <b-card-text v-if="$store.state.profile.subscription.payer_email" class="text-muted small">
                   Billed to {{ $store.state.profile.subscription.payer_email }}.
@@ -97,9 +97,9 @@
                   Payment failed
                   {{ $store.state.profile.subscription.last_payment_failed_at | formatDateHumanize }}.
                 </b-card-text>
-                <b-card-text v-else-if="$store.state.profile.subscription.ended_at">
+                <b-card-text v-else-if="$store.state.profile.subscription.ended">
                   Subscription ended
-                  {{ $store.state.profile.subscription.ended_at | formatDateHumanize }}.
+                  {{ $store.state.profile.subscription.ended | formatDateHumanize }}.
                 </b-card-text>
                 <b-card-text v-else>
                   Subscription is no longer active.


### PR DESCRIPTION
## Symptom

After a subscription activates, the Settings page goes **blank**. Console:
```
TypeError: can't access property "toUpperCase", e is undefined
  main.js:27  Settings.vue
```

## Cause

The subscription card (#22) read several fields off `subscription` that the controller's `ShardSubscriptionSummary` never returns. `subscription.vm_size` is `undefined`; piped through the `uppercase` filter (`value.toUpperCase()`, unguarded) it throws and takes down the whole view. Three more fields silently mismatched.

| Was | Now | Reason |
|---|---|---|
| `subscription.vm_size` | `profile.vm_size` | plan size is the shard's size; subscription has none (the crash) |
| `subscription.next_charge_at` | `subscription.next_billing_date` | actual summary field |
| `subscription.ended_at` | `subscription.ended` | actual field (now exposed via controller#282) |
| `uppercase(value)` | null-safe | a missing field degrades, never crashes the view |

`last_payment_failed_at` already matched; controller#282 now populates it.

## Dependencies

3-repo fix: **controller#282** (adds `last_payment_failed_at` + `ended`) → **shard_core#101** (`get-types` sync) → this. Merge in that order. core v12 bumps both shard_core + web-terminal images.

## Note / follow-up

Root cause is that there's **no generated client** binding web-terminal to the controller's OpenAPI — the card was hand-written against an assumed shape and drifted. Recommend a follow-up to generate a typed client (single source of truth = controller spec); filed separately.

## Recommended reading order

1. `src/main.js` — null-safe `uppercase` filter
2. `src/views/Settings.vue` — field alignment (active + grace)

Tracks #265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)