### PR TITLE
fix(settings): drop dead subscription-status branches

### DIFF
--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -402,7 +402,7 @@ export default {
       if (sub && sub.status === 'active') {
         return sub.pending_vm_size ? 'active-pending' : 'active';
       }
-      if (sub && ['grace', 'ended', 'suspended', 'cancelled'].includes(sub.status)) {
+      if (sub && ['grace', 'ended'].includes(sub.status)) {
         return 'grace';
       }
       if (subQuery === 'return') {
@@ -414,7 +414,7 @@ export default {
       const profile = this.$store.state.profile;
       if (!profile) return 'Subscribe';
       const sub = profile.subscription;
-      const reactivating = sub && ['grace', 'ended', 'suspended', 'cancelled'].includes(sub.status);
+      const reactivating = sub && ['grace', 'ended'].includes(sub.status);
       const verb = reactivating ? 'Reactivate' : 'Subscribe';
       const price = computeMonthlyPrice(profile.vm_size, profile.volume_size_gb);
       return `${verb} — ${formatPrice(price)}/month`;


### PR DESCRIPTION
## What

`subscriptionState` / `subscribeButtonLabel` matched `'suspended'` and `'cancelled'` status strings. The controller never emits those — `BILLING.SUBSCRIPTION.SUSPENDED`/`CANCELLED` webhooks both map to status `grace` (`paypal.py`). Backend `SubscriptionStatus` is only `active/grace/ended/error`.

Reduced the reactivatable set to `['grace', 'ended']`. No behaviour change — purely removes the stale strings.

## Release note

Cosmetic; **not worth its own web-terminal release + core bump**. Let it ride the next web-terminal release (e.g. whenever the Case 2 resize fix lands), rather than spinning v13 just for this.

Surfaced by the PayPal verification audit. Tracks #265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)