### PR TITLE
feat(settings): in-window PayPal subscribe via JS SDK (no redirect) + popup resize

### DIFF
--- a/src/lib/paypal-sdk.js
+++ b/src/lib/paypal-sdk.js
@@ -1,0 +1,15 @@
+let sdkPromise = null;
+
+export function loadPaypalSdk(clientId) {
+  if (window.paypal) return Promise.resolve(window.paypal);
+  if (sdkPromise) return sdkPromise;
+  sdkPromise = new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = `https://www.paypal.com/sdk/js?client-id=${encodeURIComponent(clientId)}&vault=true&intent=subscription`;
+    script.setAttribute('data-paypal-sdk', '');
+    script.onload = () => resolve(window.paypal);
+    script.onerror = () => { sdkPromise = null; reject(new Error('PayPal SDK failed to load')); };
+    document.head.appendChild(script);
+  });
+  return sdkPromise;
+}

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -420,7 +420,10 @@ export default {
         }
       },
     },
-    subscriptionState() {
+    subscriptionState(newState) {
+      if (!['trial', 'grace'].includes(newState)) {
+        this.paypalButtonRendered = false;
+      }
       this.$nextTick(() => this.renderPaypalButton());
     },
     '$store.state.profile.billing_enabled'() {
@@ -555,7 +558,7 @@ export default {
       if (!['trial', 'grace'].includes(this.subscriptionState)) return;
       if (this.paypalButtonRendered) return;
       const container = this.$refs.paypalButton;
-      if (!container) return;
+      if (!container || container.childElementCount > 0) return;
       try {
         await loadPaypalSdk(profile.paypal_client_id);
       } catch (e) {
@@ -565,7 +568,7 @@ export default {
       // Guard against a second render (SDK throws on a non-empty node) and
       // against re-rendering if state changed while the SDK was loading.
       if (this.paypalButtonRendered) return;
-      if (!this.$refs.paypalButton) return;
+      if (!this.$refs.paypalButton || this.$refs.paypalButton.childElementCount > 0) return;
       this.paypalButtonRendered = true;
       window.paypal.Buttons({
         createSubscription: async () => {

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -21,30 +21,12 @@
           so some settings are not available.
         </b-alert>
 
-        <b-row v-if="$store.state.profile">
+        <b-row v-if="$store.state.profile && $store.state.profile.billing_enabled">
           <b-col>
             <b-card title="Subscription">
 
-              <!-- Trial -->
-              <template v-if="subscriptionState === 'trial'">
-                <b-alert :show="cancelAlert" variant="warning" dismissible @dismissed="dismissCancelAlert">
-                  Subscription was cancelled. You can subscribe again any time.
-                </b-alert>
-                <b-card-text v-if="$store.state.profile.delete_after">
-                  Your shard will be deleted
-                  {{ $store.state.profile.delete_after | formatDateHumanize }}.
-                </b-card-text>
-                <b-card-text v-else>
-                  Subscribe to keep your shard running.
-                </b-card-text>
-                <b-button variant="primary" @click="subscribe" :disabled="subscribing">
-                  <b-spinner v-if="subscribing" small></b-spinner>
-                  {{ subscribeButtonLabel }}
-                </b-button>
-              </template>
-
-              <!-- Interstitial -->
-              <template v-else-if="subscriptionState === 'interstitial'">
+              <!-- Interstitial (driven by SDK onApprove) -->
+              <template v-if="subscribing">
                 <div class="d-flex align-items-center">
                   <b-spinner small class="mr-2"></b-spinner>
                   <span>Activating subscription…</span>
@@ -58,6 +40,21 @@
                   <b-icon-arrow-repeat></b-icon-arrow-repeat>
                   Refresh
                 </b-button>
+              </template>
+
+              <!-- Trial -->
+              <template v-else-if="subscriptionState === 'trial'">
+                <b-alert :show="cancelAlert" variant="warning" dismissible @dismissed="dismissCancelAlert">
+                  Subscription was cancelled. You can subscribe again any time.
+                </b-alert>
+                <b-card-text v-if="$store.state.profile.delete_after">
+                  Your shard will be deleted
+                  {{ $store.state.profile.delete_after | formatDateHumanize }}.
+                </b-card-text>
+                <b-card-text v-else>
+                  Subscribe to keep your shard running.
+                </b-card-text>
+                <div ref="paypalButton"></div>
               </template>
 
               <!-- Active / Active+pending -->
@@ -108,10 +105,7 @@
                   Your shard will stop
                   {{ $store.state.profile.delete_after | formatDateHumanize }}.
                 </b-card-text>
-                <b-button variant="primary" @click="subscribe" :disabled="subscribing">
-                  <b-spinner v-if="subscribing" small></b-spinner>
-                  {{ subscribeButtonLabel }}
-                </b-button>
+                <div ref="paypalButton"></div>
               </template>
 
             </b-card>
@@ -328,7 +322,8 @@ import TextField from "@/components/TextField.vue";
 import {toastMixin} from "@/mixins";
 import pjson from "@/../package.json";
 import {EventBus} from "@/event-bus";
-import {centsToEur, computeMonthlyPrice, formatPrice} from "@/lib/pricing";
+import {centsToEur, formatPrice} from "@/lib/pricing";
+import {loadPaypalSdk} from "@/lib/paypal-sdk";
 
 const INTERSTITIAL_POLL_MS = 3000;
 const INTERSTITIAL_TIMEOUT_MS = 60000;
@@ -358,6 +353,7 @@ export default {
         about: false,
       },
       subscribing: false,
+      paypalButtonRendered: false,
       cancelAlert: false,
       pollingInterval: null,
       pollingTimeoutHandle: null,
@@ -398,26 +394,13 @@ export default {
       const profile = this.$store.state.profile;
       if (!profile) return null;
       const sub = profile.subscription;
-      const subQuery = this.$route.query.sub;
       if (sub && sub.status === 'active') {
         return sub.pending_vm_size ? 'active-pending' : 'active';
       }
       if (sub && ['grace', 'ended'].includes(sub.status)) {
         return 'grace';
       }
-      if (subQuery === 'return') {
-        return 'interstitial';
-      }
       return 'trial';
-    },
-    subscribeButtonLabel() {
-      const profile = this.$store.state.profile;
-      if (!profile) return 'Subscribe';
-      const sub = profile.subscription;
-      const reactivating = sub && ['grace', 'ended'].includes(sub.status);
-      const verb = reactivating ? 'Reactivate' : 'Subscribe';
-      const price = computeMonthlyPrice(profile.vm_size, profile.volume_size_gb);
-      return `${verb} — ${formatPrice(price)}/month`;
     },
     hasPendingResize() {
       const sub = this.$store.state.profile && this.$store.state.profile.subscription;
@@ -429,12 +412,19 @@ export default {
     '$store.state.profile.subscription': {
       handler(newVal) {
         if (newVal && newVal.status === 'active') {
+          this.subscribing = false;
           this.stopInterstitialPolling();
           if (this.$route.query.sub) {
             this.$router.replace({query: {}}).catch(() => {});
           }
         }
       },
+    },
+    subscriptionState() {
+      this.$nextTick(() => this.renderPaypalButton());
+    },
+    '$store.state.profile.billing_enabled'() {
+      this.$nextTick(() => this.renderPaypalButton());
     },
   },
 
@@ -524,12 +514,29 @@ export default {
     },
     async resizeShard() {
       this.resize.waitingForRestart = true;
+      // Set when a PayPal popup is in flight: the popup-close watcher owns
+      // resetting waitingForRestart, so the finally block must not clear it.
+      let popupInFlight = false;
       try {
         const response = await this.$http.post(
             '/core/protected/management/api/shards/self/resize',
             {new_vm_size: this.resize.selectedSize});
         if (response.data && response.data.approval_url) {
-          window.location = response.data.approval_url;
+          // The POST already happened, so we cannot open the popup synchronously
+          // on the click; if the browser blocks it, fall back to a redirect.
+          const popup = window.open(response.data.approval_url, 'paypal-revise', 'width=500,height=700');
+          if (!popup) {
+            window.location = response.data.approval_url;
+            return;
+          }
+          popupInFlight = true;
+          const timer = setInterval(async () => {
+            if (popup.closed) {
+              clearInterval(timer);
+              await this.$store.dispatch('force_query_profile_data').catch(() => {});
+              this.resize.waitingForRestart = false;
+            }
+          }, 800);
           return;
         }
         await this.$router.replace('/restart');
@@ -537,25 +544,49 @@ export default {
         this.toastError('Error during resize', e.response.data.detail);
         await this.$store.dispatch('force_query_profile_data').catch(() => {});
       } finally {
-        this.resize.waitingForRestart = false;
+        if (!popupInFlight) {
+          this.resize.waitingForRestart = false;
+        }
       }
     },
-    async subscribe() {
-      this.subscribing = true;
+    async renderPaypalButton() {
+      const profile = this.$store.state.profile;
+      if (!profile || !profile.billing_enabled) return;
+      if (!['trial', 'grace'].includes(this.subscriptionState)) return;
+      if (this.paypalButtonRendered) return;
+      const container = this.$refs.paypalButton;
+      if (!container) return;
       try {
-        const response = await this.$http.post(
-            '/core/protected/management/api/shards/self/subscribe');
-        if (response.data && response.data.approval_url) {
-          window.location = response.data.approval_url;
-          return;
-        }
-        this.toastError('Subscription error', 'No approval URL returned.');
+        await loadPaypalSdk(profile.paypal_client_id);
       } catch (e) {
-        const detail = (e.response && e.response.data && e.response.data.detail) || e.message;
-        this.toastError('Subscription error', detail);
-      } finally {
-        this.subscribing = false;
+        this.toastError('PayPal error', 'Could not load PayPal.');
+        return;
       }
+      // Guard against a second render (SDK throws on a non-empty node) and
+      // against re-rendering if state changed while the SDK was loading.
+      if (this.paypalButtonRendered) return;
+      if (!this.$refs.paypalButton) return;
+      this.paypalButtonRendered = true;
+      window.paypal.Buttons({
+        createSubscription: async () => {
+          const {data} = await this.$http.post(
+              '/core/protected/management/api/shards/self/subscribe');
+          return data.subscription_id;
+        },
+        onApprove: async () => {
+          this.subscribing = true;
+          // Poll until the webhook flips the subscription to active; the
+          // subscription watcher stops polling and clears `subscribing`.
+          this.startInterstitialPolling();
+          await this.$store.dispatch('force_query_profile_data');
+        },
+        onCancel: () => {
+          this.toastError('Subscription', 'Subscription was not completed');
+        },
+        onError: (err) => {
+          this.toastError('PayPal error', String(err));
+        },
+      }).render(this.$refs.paypalButton);
     },
     startInterstitialPolling() {
       this.stopInterstitialPolling();
@@ -600,17 +631,11 @@ export default {
     });
 
     const subQuery = this.$route.query.sub;
-    if (subQuery === 'return') {
-      const sub = this.$store.state.profile && this.$store.state.profile.subscription;
-      if (sub && sub.status === 'active') {
-        // WS or earlier refetch already converged → drop the query param.
-        await this.$router.replace({query: {}}).catch(() => {});
-      } else {
-        this.startInterstitialPolling();
-      }
-    } else if (subQuery === 'cancel') {
+    if (subQuery === 'cancel') {
       this.cancelAlert = true;
     }
+
+    this.$nextTick(() => this.renderPaypalButton());
 
     const section = this.$router.currentRoute.hash.replace("#", "");
     if (section) {

--- a/tests/unit/paypal-sdk.spec.js
+++ b/tests/unit/paypal-sdk.spec.js
@@ -1,0 +1,18 @@
+import { loadPaypalSdk } from '@/lib/paypal-sdk';
+
+describe('loadPaypalSdk', () => {
+  beforeEach(() => { document.head.innerHTML = ''; window.paypal = undefined; });
+
+  it('injects the SDK script once with the client id + subscription intent', async () => {
+    const p = loadPaypalSdk('CID');
+    const script = document.querySelector('script[data-paypal-sdk]');
+    expect(script).not.toBeNull();
+    expect(script.src).toContain('client-id=CID');
+    expect(script.src).toContain('intent=subscription');
+    window.paypal = {};
+    script.onload();
+    await expect(p).resolves.toBe(window.paypal);
+    await loadPaypalSdk('CID');
+    expect(document.querySelectorAll('script[data-paypal-sdk]').length).toBe(1);
+  });
+});


### PR DESCRIPTION
## What

Frontend half of the in-window PayPal flow (spec: `knowledge_base/specs/2026-06-03-paypal-in-window-subscribe-design.md`). Replaces the full-page redirect with PayPal's JS SDK — the user never leaves the shard, and there is **no `return_url`** (removes the hash-route mangling bug class).

- **Capability gate:** the whole subscription section renders, and the SDK loads, only when `profile.billing_enabled` is true. Self-hosted/disabled shards show nothing and load no PayPal JS.
- **SDK loader** (`src/lib/paypal-sdk.js`): loads `www.paypal.com/sdk/js` once, intent=subscription, with the public client id from the self-view. Unit-tested.
- **Subscribe/reactivate:** the SDK button's `createSubscription` calls `POST .../shards/self/subscribe` (server-created, returns `subscription_id`); `onApprove` triggers a profile refresh + the existing interstitial/poll. Removed the old redirect + `?sub=return` handling. The SDK opens a real popup window (matches the desired UX).
- **Resize:** subscribed-resize approval opens via `window.open(approval_url)` (popup; SDK has no revise action — per spike), with a redirect fallback if the popup is blocked, and a `popup.closed` poll to refresh.

## Depends on

freeshard-controller#286 (provides `billing_enabled` / `paypal_client_id` on the self-view, and `subscription_id` from subscribe/resize). Deploy that first.

## Verification

Unit: SDK loader spec + existing suite (14/14). Build compiles. **The SDK flow itself requires live sandbox browser verification** (cannot be unit-tested): subscribe, reactivate-from-grace, resize — all in-window. Spike already confirmed the SDK loads + approves in-window and that resize needs the popup.

Live-test watch items (flagged during implementation): SDK button re-render on trial↔grace transitions in one session (addressed by `fa3b70a` — confirm); popup-blocker fallback on resize.

## Recommended reading order

1. `src/lib/paypal-sdk.js` (+ `tests/unit/paypal-sdk.spec.js`) — the loader
2. `src/views/Settings.vue` — gate, SDK button (`renderPaypalButton`), `resizeShard` popup

Tracks #265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)