### PR TITLE
fix: refresh profile on websocket reconnect

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -39,7 +39,14 @@ export default {
         this.websocket = null;
       };
       this.websocket.onopen = () => {
+        // On a reconnect (e.g. after a resize restarts the shard) re-pull the
+        // profile so size/price reflect the new state. Skip on the first open;
+        // beforeMount already loaded it.
+        const wasDisconnected = this.$store.state.websocket.disconnectedSince !== null;
         this.$store.commit('websocket_connect');
+        if (wasDisconnected) {
+          this.$store.dispatch('force_query_profile_data').catch(() => {});
+        }
       };
     },
   },


### PR DESCRIPTION
## Problem

After a subscribed resize, the controller restarts the shard to apply the new VM size. This drops the management websocket; the client reconnects (1s interval in `App.vue`), but the profile is never re-fetched — so the Settings UI keeps showing the old size and price even though the backend has updated them.

## Fix

In the websocket `onopen` handler, when the socket was previously disconnected (a reconnect, not the first open), dispatch `force_query_profile_data` (which fetches `/management/profile?refresh=true`, forcing shard-core to re-pull the controller self-view). The first open is skipped because `beforeMount` already loads the profile.

Pairs with the controller-side fix that promotes the price and clears the pending-resize slot on approval (FreeshardBase/freeshard-controller#292).

## Note

Not built locally (Vue-CLI toolchain not installed in this worktree). The change mirrors existing call sites — `force_query_profile_data` (store.js), `websocket.disconnectedSince` state, and the same `.catch(() => {})` pattern used in `Settings.vue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)