### PR TITLE
feat(pricing): drop flat fee, add 19% German VAT

### DIFF
--- a/src/lib/pricing.js
+++ b/src/lib/pricing.js
@@ -36,3 +36,10 @@ export function centsToEur(cents) {
   if (cents == null) return null;
   return Math.round(cents) / 100;
 }
+
+// VAT share of a gross price (gross already includes 19% VAT), in euros.
+export function vatAmountEur(grossCents) {
+  if (grossCents == null) return null;
+  const net = Math.round(grossCents / VAT_MULTIPLIER);
+  return (grossCents - net) / 100;
+}

--- a/src/lib/pricing.js
+++ b/src/lib/pricing.js
@@ -12,8 +12,8 @@ export const VM_PRICING_EUR = {
 };
 
 export const DISK_PRICE_PER_GB_EUR = 0.04;
-export const MANAGEMENT_COST_EUR = 3.00;
 export const MARGIN_MULTIPLIER = 1.5;
+export const VAT_MULTIPLIER = 1.19;
 
 export function computeMonthlyPrice(vmSize, volumeSizeGb) {
   if (!vmSize) return null;
@@ -21,8 +21,9 @@ export function computeMonthlyPrice(vmSize, volumeSizeGb) {
   if (vmCost === undefined) return null;
   if (!Number.isFinite(volumeSizeGb)) return null;
   const total =
-    (vmCost + volumeSizeGb * DISK_PRICE_PER_GB_EUR + MANAGEMENT_COST_EUR) *
-    MARGIN_MULTIPLIER;
+    (vmCost + volumeSizeGb * DISK_PRICE_PER_GB_EUR) *
+    MARGIN_MULTIPLIER *
+    VAT_MULTIPLIER;
   return Math.round(total * 100) / 100;
 }
 

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -59,9 +59,12 @@
 
               <!-- Active / Active+pending -->
               <template v-else-if="subscriptionState === 'active' || subscriptionState === 'active-pending'">
-                <b-card-text>
+                <b-card-text class="mb-1">
                   Plan: <b>{{ $store.state.profile.vm_size | uppercase }}</b>
                   — {{ formatPrice(centsToEur($store.state.profile.subscription.price_cents)) }}/month
+                </b-card-text>
+                <b-card-text class="text-muted small">
+                  incl. 19% VAT ({{ formatPrice(vatAmountEur($store.state.profile.subscription.price_cents)) }})
                 </b-card-text>
                 <b-card-text v-if="$store.state.profile.subscription.next_billing_date">
                   Next charge {{ $store.state.profile.subscription.next_billing_date | formatDateHumanize }}.
@@ -76,7 +79,10 @@
                   Upgrade pending:
                   <b>{{ $store.state.profile.subscription.pending_vm_size | uppercase }}</b>
                   at
-                  {{ formatPrice(centsToEur($store.state.profile.subscription.pending_price_cents)) }}/month.
+                  {{ formatPrice(centsToEur($store.state.profile.subscription.pending_price_cents)) }}/month
+                  <span class="text-muted small">
+                    (incl. 19% VAT {{ formatPrice(vatAmountEur($store.state.profile.subscription.pending_price_cents)) }})
+                  </span>.
                 </b-alert>
                 <b-button
                     variant="outline-primary"
@@ -323,7 +329,7 @@ import TextField from "@/components/TextField.vue";
 import {toastMixin} from "@/mixins";
 import pjson from "@/../package.json";
 import {EventBus} from "@/event-bus";
-import {centsToEur, formatPrice} from "@/lib/pricing";
+import {centsToEur, formatPrice, vatAmountEur} from "@/lib/pricing";
 import {loadPaypalSdk} from "@/lib/paypal-sdk";
 
 const INTERSTITIAL_POLL_MS = 3000;
@@ -683,6 +689,7 @@ export default {
     },
     centsToEur,
     formatPrice,
+    vatAmountEur,
   },
 
   async mounted() {

--- a/tests/unit/pricing.spec.js
+++ b/tests/unit/pricing.spec.js
@@ -2,6 +2,7 @@ import {
   centsToEur,
   computeMonthlyPrice,
   formatPrice,
+  vatAmountEur,
 } from '@/lib/pricing';
 
 describe('computeMonthlyPrice', () => {
@@ -51,5 +52,21 @@ describe('formatPrice', () => {
 describe('centsToEur', () => {
   test('converts cents to euros', () => {
     expect(centsToEur(2130)).toBe(21.30);
+  });
+});
+
+describe('vatAmountEur', () => {
+  // VAT share of a gross price: gross - round(gross/1.19)
+  test('s + 30GB gross 2178c => 3.48', () => {
+    expect(vatAmountEur(2178)).toBe(3.48);
+  });
+  test('m + 100GB gross 4248c => 6.78', () => {
+    expect(vatAmountEur(4248)).toBe(6.78);
+  });
+  test('xl + 400GB gross 21063c => 33.63', () => {
+    expect(vatAmountEur(21063)).toBe(33.63);
+  });
+  test('null => null', () => {
+    expect(vatAmountEur(null)).toBeNull();
   });
 });

--- a/tests/unit/pricing.spec.js
+++ b/tests/unit/pricing.spec.js
@@ -5,24 +5,24 @@ import {
 } from '@/lib/pricing';
 
 describe('computeMonthlyPrice', () => {
-  // (11.00 + 30*0.04 + 3.00) * 1.5 = 22.80
-  test('s + 30GB => 22.80', () => {
-    expect(computeMonthlyPrice('s', 30)).toBe(22.80);
+  // (11.00 + 30*0.04) * 1.5 * 1.19 = 21.78
+  test('s + 30GB => 21.78', () => {
+    expect(computeMonthlyPrice('s', 30)).toBe(21.78);
   });
 
-  // (5.50 + 20*0.04 + 3.00) * 1.5 = 13.95
-  test('xs + 20GB => 13.95', () => {
-    expect(computeMonthlyPrice('xs', 20)).toBe(13.95);
+  // (5.50 + 20*0.04) * 1.5 * 1.19 = 11.25
+  test('xs + 20GB => 11.25', () => {
+    expect(computeMonthlyPrice('xs', 20)).toBe(11.25);
   });
 
-  // (102.00 + 400*0.04 + 3.00) * 1.5 = 181.50
-  test('xl + 400GB => 181.50', () => {
-    expect(computeMonthlyPrice('xl', 400)).toBe(181.50);
+  // (102.00 + 400*0.04) * 1.5 * 1.19 = 210.63
+  test('xl + 400GB => 210.63', () => {
+    expect(computeMonthlyPrice('xl', 400)).toBe(210.63);
   });
 
-  // (19.80 + 250*0.04 + 3.00) * 1.5 = 49.20
-  test('m + 250GB => 49.20', () => {
-    expect(computeMonthlyPrice('m', 250)).toBe(49.20);
+  // (19.80 + 250*0.04) * 1.5 * 1.19 = 53.19
+  test('m + 250GB => 53.19', () => {
+    expect(computeMonthlyPrice('m', 250)).toBe(53.19);
   });
 
   test('missing vmSize => null', () => {


### PR DESCRIPTION
## What

Mirrors the backend pricing change in the Subscribe-card price helper:

```
old:  (vmCost + volumeSizeGb*0.04 + 3.00) * 1.5
new:  (vmCost + volumeSizeGb*0.04) * 1.5 * 1.19
```

- Removes the flat €3.00 (was a revenue share, not management cost).
- Adds 19% German VAT (`VAT_MULTIPLIER = 1.19`). Displayed price is now gross.
- Drops the now-unused `MANAGEMENT_COST_EUR` constant.

Only affects the Subscribe / Reactivate button **label** for not-yet-subscribed shards. Active/grace subscribers still render the controller-supplied `price_cents` and stay grandfathered.

## Sibling PRs (same change, must merge together)

- controller (canonical): https://github.com/FreeshardBase/freeshard-controller/pull/298
- landing-page: https://github.com/FreeshardBase/landing-page/pull/15

## Tests

`vue-cli-service test:unit` → **14 passed** incl `pricing.spec.js` (4 expected values recomputed: xs+20=€11.25, s+30=€21.78, m+250=€53.19, xl+400=€210.63).

## Recommended reading order

1. `src/lib/pricing.js` — the formula + constants
2. `tests/unit/pricing.spec.js` — pinned expected values

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 2nd commit — VAT transparency

Adds a muted `incl. 19% VAT (€X.XX)` line under the active-plan price and the pending-upgrade price in the subscription card (`Settings.vue`), using Bootstrap's `text-muted small`. The gross price stays prominent.

New `vatAmountEur(grossCents)` helper in `pricing.js` = `gross - round(gross/1.19)`, with unit tests (4 cases). `vue-cli-service test:unit` → 18 passed; lint clean.
