### PR TITLE
fix: sort app grid icons by name

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -66,7 +66,7 @@ const store = new Vuex.Store({
             state.websocket.disconnectedSince = Date.now();
         },
         set_apps(state, apps) {
-            state.apps = apps;
+            state.apps = [...apps].sort((a, b) => a.name.localeCompare(b.name));
         },
         set_terminals(state, terminals) {
             state.terminals = terminals;

--- a/tests/unit/store.spec.js
+++ b/tests/unit/store.spec.js
@@ -44,3 +44,14 @@ describe('handle_websocket_message', () => {
     expect(httpGet).not.toHaveBeenCalled();
   });
 });
+
+describe('set_apps', () => {
+  test('sorts apps by name', () => {
+    store.commit('set_apps', [
+      {name: 'zulu'},
+      {name: 'alpha'},
+      {name: 'Mike'},
+    ]);
+    expect(store.state.apps.map(a => a.name)).toEqual(['alpha', 'Mike', 'zulu']);
+  });
+});


### PR DESCRIPTION
## Problem

App icons on the home grid had no defined order and jumped around. Apps arrive in arbitrary backend order via both the HTTP refresh (`/core/protected/apps`) and the `apps_update` websocket message, and the `set_apps` mutation stored that order verbatim.

## Fix

Sort apps by name (`localeCompare`) inside the `set_apps` Vuex mutation, so every consumer sees a stable, name-ordered list regardless of update source.

## Testing

- Added a unit test asserting `set_apps` sorts by name (case-insensitive via `localeCompare`)
- Full suite: 19/19 passing
- ESLint: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)