### PR TITLE
Show PAUSED app state in the app detail modal and grid

### DIFF
--- a/src/components/AppIcon.vue
+++ b/src/components/AppIcon.vue
@@ -15,6 +15,7 @@
     </div>
     <div class="status text-secondary">
       <b-icon-circle-fill v-if="app.status === 'running'"></b-icon-circle-fill>
+      <b-icon-circle-fill v-else-if="app.status === 'paused'" class="paused-dot"></b-icon-circle-fill>
       <div v-else></div>
     </div>
     <div>{{ (app.meta && app.meta.pretty_name) || app.name }}</div>
@@ -119,6 +120,10 @@ p {
 .status > * {
   height: 0.5em;
   width: 0.5em;
+}
+
+.paused-dot {
+  opacity: 0.4;
 }
 
 .grid {

--- a/src/components/AppStoreEntry.vue
+++ b/src/components/AppStoreEntry.vue
@@ -29,6 +29,8 @@
                   v-if="!isSizeCompatible" variant="warning"></b-icon-exclamation-octagon-fill>
               <b-icon-exclamation-triangle-fill
                   v-if="app.status === 'error'" variant="danger"></b-icon-exclamation-triangle-fill>
+              <b-icon-pause-circle-fill
+                  v-if="app.status === 'paused'" variant="secondary"></b-icon-pause-circle-fill>
             </b-card-title>
             <b-card-text>{{ appStoreInfo.description_short }}</b-card-text>
           </b-card-body>
@@ -55,7 +57,11 @@
                 {{ app.pretty_name || (app.meta && app.meta.pretty_name) || app.name }}
               </h2>
               <p class="text-secondary" v-if="is_installed"><small>
-                {{ app.status }}<br>
+                <span v-if="app.status === 'paused'">
+                  <b-icon-pause-circle-fill></b-icon-pause-circle-fill>
+                  Paused — wakes automatically on access
+                </span>
+                <span v-else>{{ app.status }}</span><br>
                 <div v-if="app.installation_reason === 'custom'">Custom App</div>
                 <div v-if="app.installation_reason === 'config'">Preconfigured App</div>
               </small></p>

--- a/src/views/Apps.vue
+++ b/src/views/Apps.vue
@@ -198,7 +198,7 @@ export default {
       const this_ = this;
       return this.$store.state.apps.filter(app => {
         const storeApp = this_.storeApps.find(a => a.name === app.name);
-        return storeApp !== undefined && app.meta && app.meta.app_version !== storeApp.app_version && ['stopped', 'running', 'down'].includes(app.status);
+        return storeApp !== undefined && app.meta && app.meta.app_version !== storeApp.app_version && ['stopped', 'running', 'down', 'paused'].includes(app.status);
       })
     }
   },


### PR DESCRIPTION
Closes #33

## What

Render the new shard_core `paused` app status (containers frozen, memory paged to swap, wakes on request in ms–2s) so a paused app reads as **available**, not stopped or broken.

- **App detail modal** (`AppStoreEntry.vue`): pause icon in the card title (next to the existing error/featured/size icons) and a `⏸ Paused — wakes automatically on access` line in the modal header, replacing the raw status string only for `paused`. Other states are unchanged. The **Open** button already renders for `paused` (only hidden on `error`), so launch works exactly as today — wake is server-side.
- **Grid icon** (`AppIcon.vue`): a muted (40% opacity) status dot for `paused`, distinct from the solid running dot and from the empty stopped state. Matches @max-tet's request for a muted dot.
- **Update gate** (`Apps.vue`): include `paused` in the update-available filter (`['stopped','running','down','paused']`) so a paused app with a newer store version still surfaces an update. Reinstall handles state via shard_core.

No API change — `status` already arrives via `GET /core/protected/apps`.

## Acceptance criteria

- ✅ A paused app shows a recognizable paused indication in the detail modal, distinct from stopped/error.
- ✅ Opening the app still works exactly as today (wake-on-request is server-side).

## Verification

- `npm run lint` → no errors
- `npm run build` → build complete

## Recommended reading order

1. `src/components/AppIcon.vue` — grid dot
2. `src/components/AppStoreEntry.vue` — modal + card title
3. `src/views/Apps.vue` — update gate
