### PR TITLE
Settings: show price before PayPal (subscribe + resize) + merge size/subscription sections

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -34,10 +34,13 @@ src/
     Pair.vue             Device pairing form (enter code)
     Terminals.vue        Manage paired devices, generate QR pairing codes
     Apps.vue             App store: browse, install, update, custom app upload
-    Settings.vue         Shard config, backups, disk usage, resize, about
+    Settings.vue         Shard config, backups, disk usage, subscription + size, about
     Public.vue           Edit own profile (name, email, avatar)
     Peers.vue            Peer management (currently hidden)
-    Restart.vue          Redirect target after shard restart
+    Restart.vue          Interstitial while the shard restarts; returns to /settings
+  lib/                 Framework-free helpers (plain JS, unit-tested)
+    pricing.js           Client-side mirror of the controller's price formula
+    paypal-sdk.js        Loads the PayPal JS SDK once, on demand
   components/          13 reusable UI components
     Navbar.vue           Sticky nav with feedback modal, version update notification, disk warnings
     AppIcon.vue          App launcher tile with status indicator
@@ -82,6 +85,23 @@ Single-file store with:
 - Computed properties for derived state
 - Local `editMode` boolean pattern for inline editing (see TerminalCard)
 - `toastMixin` for toast notifications on success/error
+
+### Subscription & Size (Settings.vue)
+Size and subscription are one card: a resize on a subscribed shard *is* a billing
+change, so the two are presented together.
+
+- **The monthly price must be visible in our UI before the buyer is sent to PayPal**
+  (German consumer law). Do not regress this to "PayPal shows it on its own screen".
+- `lib/pricing.js` mirrors the controller's `compute_price` by hand — formula *and*
+  half-up rounding. If they drift, the previewed price disagrees with the actual
+  charge. Change both together.
+- Prices are gross (incl. 19% VAT). A price is only shown when `profile.volume_size_gb`
+  is known; the controller rejects subscribe with 422 otherwise.
+- Active/grace render the controller's `subscription.price_cents` so existing
+  subscribers stay grandfathered. Only previews are computed client-side.
+- Two resize paths: unsubscribed resizes immediately; subscribed must authorize the
+  new price via the PayPal SDK (`revise`), and the actual resize is triggered by the
+  `BILLING.SUBSCRIPTION.UPDATED` webhook. Both hand off to `/restart`.
 
 ### App Store
 App metadata fetched from external Azure blob storage. Supports branch switching (main/dev) for testing unreleased apps.

--- a/src/lib/pricing.js
+++ b/src/lib/pricing.js
@@ -1,7 +1,8 @@
 // Pricing helper — mirrors landing-page/src/components/Pricing.astro.
-// Used by the Subscription card to compute the Subscribe / Reactivate
-// button label. Active / Grace states render the controller-supplied
-// `price_cents` directly so existing subscribers stay grandfathered.
+// Used by the Subscription card to preview the monthly price of a size
+// before the buyer is sent to PayPal. Active / Grace states render the
+// controller-supplied `price_cents` directly so existing subscribers stay
+// grandfathered.
 
 export const VM_PRICING_EUR = {
   xs: 5.50,
@@ -30,6 +31,12 @@ export function computeMonthlyPrice(vmSize, volumeSizeGb) {
 export function formatPrice(amount) {
   if (amount == null) return '€—';
   return `€${amount.toFixed(2)}`;
+}
+
+export function formatPriceDelta(amount) {
+  if (amount == null) return '€—';
+  const sign = amount < 0 ? '-' : '+';
+  return `${sign}${formatPrice(Math.abs(amount))}`;
 }
 
 export function centsToEur(cents) {

--- a/src/views/Restart.vue
+++ b/src/views/Restart.vue
@@ -80,7 +80,8 @@ export default {
         return;
       }
       if (this.phase === 'unresponsive') {
-        window.location.replace('/');
+        // Full load, not a route push: the shard restarted, so all state is stale.
+        window.location.replace('/settings');
       }
     },
   },

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -481,12 +481,13 @@ export default {
   },
 
   watch: {
-    'resize.selectedSize'(newSize) {
-      if (newSize && this.resizeNeedsApproval) {
-        this.$nextTick(() => this.renderResizeButton());
-      } else {
-        this.teardownResizeButton();
-      }
+    'resize.selectedSize'() {
+      this.syncResizeButton();
+    },
+    resizeNeedsApproval() {
+      // A size can already be selected when the shard gains a subscription,
+      // and the approval button only enters the DOM at that point.
+      this.syncResizeButton();
     },
     hasPendingResize(now, was) {
       // pending cleared by the UPDATED webhook → the resize is committed.
@@ -620,6 +621,13 @@ export default {
     cancelResizeSelection() {
       // Watcher tears down the PayPal button when selectedSize clears.
       this.resize.selectedSize = null;
+    },
+    syncResizeButton() {
+      if (this.resize.selectedSize && this.resizeNeedsApproval) {
+        this.$nextTick(() => this.renderResizeButton());
+      } else {
+        this.teardownResizeButton();
+      }
     },
     teardownResizeButton() {
       if (this.resizeButtonInstance) {

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -662,11 +662,10 @@ export default {
         },
         onApprove: async () => {
           // The UPDATED webhook promotes the price, clears pending and resizes
-          // the VM; poll until the profile reflects it (hasPendingResize watcher
-          // then clears waitingForRestart).
+          // the VM. The restart screen polls the shard until it comes back, so
+          // hand off to it rather than polling on a busy Settings page.
           this.resize.waitingForRestart = true;
-          this.startInterstitialPolling();
-          await this.$store.dispatch('force_query_profile_data').catch(() => {});
+          await this.$router.replace('/restart');
         },
         onCancel: async () => {
           await cancelPending();

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -21,9 +21,82 @@
           so some settings are not available.
         </b-alert>
 
-        <b-row v-if="$store.state.profile && $store.state.profile.billing_enabled">
+        <b-row id="size" v-if="$store.state.profile">
           <b-col>
-            <b-card title="Subscription">
+          <b-overlay :show="navOverlays.size" variant="primary" rounded="sm">
+
+            <!-- to remove the spinner -->
+            <template #overlay><div></div></template>
+
+            <b-card :title="billingEnabled ? 'Subscription &amp; Size' : 'Size'">
+
+              <!-- ===================== Size ===================== -->
+              <template v-if="!subscribing">
+                <b-card-text>
+                  Change the size of your Shard.
+                  This sets the number of CPUs and the amount of RAM your Shard can use.
+                </b-card-text>
+                <b-card-text class="text-muted small">
+                  To unlock larger sizes, please <a href="mailto:contact@freeshard.net">contact us</a>.
+                </b-card-text>
+
+                <b-button-group>
+                  <b-button
+                      v-for="size in resize.sizes"
+                      :key="size"
+                      @click="resize.selectedSize=size"
+                      :disabled="!sizeIsAvailable(size) || resize.waitingForRestart || hasPendingResize"
+                      :variant="variantForSize(size)">
+                    {{ size | uppercase }}
+                  </b-button>
+                </b-button-group>
+
+                <div v-if="resize.selectedSize" class="mt-3">
+                  <b-card-text v-if="selectedSizePrice !== null" class="mb-1">
+                    New price: <b>{{ formatPrice(selectedSizePrice) }}</b>/month
+                    <span v-if="priceDelta !== null" class="text-muted">
+                      ({{ formatPriceDelta(priceDelta) }} vs. current)
+                    </span>
+                  </b-card-text>
+                  <b-card-text v-if="selectedSizePrice !== null" class="text-muted small">
+                    incl. 19% VAT ({{ formatPrice(vatOf(selectedSizePrice)) }})
+                  </b-card-text>
+                  <b-card-text class="small">
+                    <span v-if="resizeNeedsApproval">
+                      Approve the new price to resize to {{ resize.selectedSize | uppercase }}.
+                    </span>
+                    <span v-else>
+                      Resize to {{ resize.selectedSize | uppercase }}.
+                    </span>
+                    The shard restarts afterwards.
+                  </b-card-text>
+                  <!-- PayPal SDK revise button; performs actions.subscription.revise in-window. -->
+                  <div v-if="resizeNeedsApproval" ref="resizeButton" class="paypal-action mt-2"></div>
+                  <b-button
+                      v-else
+                      variant="primary"
+                      class="mt-2"
+                      @click="resizeShard"
+                      :disabled="resize.waitingForRestart">
+                    Resize
+                  </b-button>
+                  <div>
+                    <b-button variant="link" size="sm" class="text-danger px-0"
+                              @click="cancelResizeSelection" :disabled="resize.waitingForRestart">
+                      Cancel
+                    </b-button>
+                  </div>
+                </div>
+
+                <b-card-text v-if="hasPendingResize" class="text-muted small mt-2">
+                  A size change is already pending; new resizes are disabled until it completes.
+                </b-card-text>
+              </template>
+
+              <hr v-if="billingEnabled && !subscribing">
+
+              <!-- ================= Subscription ================= -->
+              <template v-if="billingEnabled">
 
               <!-- Interstitial (driven by SDK onApprove) -->
               <template v-if="subscribing">
@@ -54,7 +127,14 @@
                 <b-card-text v-else>
                   Subscribe to keep your shard running.
                 </b-card-text>
-                <div ref="paypalButton"></div>
+                <b-card-text v-if="currentSizePrice !== null" class="mb-1">
+                  <b>{{ $store.state.profile.vm_size | uppercase }}</b>
+                  — <b>{{ formatPrice(currentSizePrice) }}</b>/month
+                </b-card-text>
+                <b-card-text v-if="currentSizePrice !== null" class="text-muted small">
+                  incl. 19% VAT ({{ formatPrice(vatOf(currentSizePrice)) }})
+                </b-card-text>
+                <div ref="paypalButton" class="paypal-action mt-2"></div>
               </template>
 
               <!-- Active / Active+pending -->
@@ -111,10 +191,20 @@
                   Your shard will stop
                   {{ $store.state.profile.delete_after | formatDateHumanize }}.
                 </b-card-text>
-                <div ref="paypalButton"></div>
+                <b-card-text v-if="currentSizePrice !== null" class="mb-1">
+                  <b>{{ $store.state.profile.vm_size | uppercase }}</b>
+                  — <b>{{ formatPrice(currentSizePrice) }}</b>/month
+                </b-card-text>
+                <b-card-text v-if="currentSizePrice !== null" class="text-muted small">
+                  incl. 19% VAT ({{ formatPrice(vatOf(currentSizePrice)) }})
+                </b-card-text>
+                <div ref="paypalButton" class="paypal-action mt-2"></div>
+              </template>
+
               </template>
 
             </b-card>
+            </b-overlay>
           </b-col>
         </b-row>
 
@@ -224,54 +314,6 @@
           </b-col>
         </b-row>
 
-        <b-row id="size" v-if="$store.state.profile">
-          <b-col>
-          <b-overlay :show="navOverlays.size" variant="primary" rounded="sm">
-
-            <!-- to remove the spinner -->
-            <template #overlay><div></div></template>
-
-            <b-card title="Size">
-              <b-card-text>
-                Change the size of your Shard.
-                This sets the number of CPUs and the amount of RAM your Shard can use.
-              </b-card-text>
-              <b-card-text class="text-muted small">
-                To unlock larger sizes, please <a href="mailto:contact@freeshard.net">contact us</a>.
-              </b-card-text>
-
-              <b-button-group>
-                <b-button
-                    v-for="size in resize.sizes"
-                    :key="size"
-                    @click="resize.selectedSize=size"
-                    :disabled="!sizeIsAvailable(size) || resize.waitingForRestart || hasPendingResize"
-                    :variant="variantForSize(size)">
-                  {{ size | uppercase }}
-                </b-button>
-              </b-button-group>
-
-              <div v-if="resize.selectedSize" class="ml-3 d-inline-block align-top">
-                <b-card-text class="small mb-1">
-                  Approve the new price to resize to {{ resize.selectedSize | uppercase }}. The shard restarts afterwards.
-                </b-card-text>
-                <!-- PayPal SDK revise button; performs actions.subscription.revise in-window. -->
-                <div ref="resizeButton"></div>
-                <b-button variant="link" size="sm" class="text-danger px-0"
-                          @click="cancelResizeSelection" :disabled="resize.waitingForRestart">
-                  Cancel
-                </b-button>
-              </div>
-
-              <b-card-text v-if="hasPendingResize" class="text-muted small mt-2">
-                A size change is already pending; new resizes are disabled until it completes.
-              </b-card-text>
-
-            </b-card>
-            </b-overlay>
-          </b-col>
-        </b-row>
-
         <b-row>
           <b-col>
             <b-card title="Reset Welcome Screen">
@@ -329,7 +371,7 @@ import TextField from "@/components/TextField.vue";
 import {toastMixin} from "@/mixins";
 import pjson from "@/../package.json";
 import {EventBus} from "@/event-bus";
-import {centsToEur, formatPrice, vatAmountEur} from "@/lib/pricing";
+import {centsToEur, computeMonthlyPrice, formatPrice, formatPriceDelta, vatAmountEur} from "@/lib/pricing";
 import {loadPaypalSdk} from "@/lib/paypal-sdk";
 
 const INTERSTITIAL_POLL_MS = 3000;
@@ -397,6 +439,24 @@ export default {
       } else {
         return 'success';
       }
+    },
+    billingEnabled() {
+      const p = this.$store.state.profile;
+      return !!(p && p.billing_enabled);
+    },
+    currentSizePrice() {
+      const p = this.$store.state.profile;
+      if (!p) return null;
+      return computeMonthlyPrice(p.vm_size, p.volume_size_gb);
+    },
+    selectedSizePrice() {
+      const p = this.$store.state.profile;
+      if (!p || !this.resize.selectedSize) return null;
+      return computeMonthlyPrice(this.resize.selectedSize, p.volume_size_gb);
+    },
+    priceDelta() {
+      if (this.selectedSizePrice === null || this.currentSizePrice === null) return null;
+      return Math.round((this.selectedSizePrice - this.currentSizePrice) * 100) / 100;
     },
     subscriptionState() {
       const profile = this.$store.state.profile;
@@ -687,8 +747,13 @@ export default {
         this.$router.replace({query: {}}).catch(() => {});
       }
     },
+    vatOf(eur) {
+      if (eur == null) return null;
+      return vatAmountEur(Math.round(eur * 100));
+    },
     centsToEur,
     formatPrice,
+    formatPriceDelta,
     vatAmountEur,
   },
 
@@ -738,6 +803,11 @@ export default {
 
 .text-monospace {
   white-space: pre;
+}
+
+/* PayPal SDK buttons render full-width; keep them from spanning the card. */
+.paypal-action {
+  max-width: 300px;
 }
 
 </style>

--- a/tests/unit/pricing.spec.js
+++ b/tests/unit/pricing.spec.js
@@ -2,6 +2,7 @@ import {
   centsToEur,
   computeMonthlyPrice,
   formatPrice,
+  formatPriceDelta,
   vatAmountEur,
 } from '@/lib/pricing';
 
@@ -46,6 +47,25 @@ describe('formatPrice', () => {
 
   test('returns dash for null', () => {
     expect(formatPrice(null)).toBe('€—');
+  });
+});
+
+describe('formatPriceDelta', () => {
+  // m + 30GB (37.34) minus s + 30GB (21.78)
+  test('signs an upgrade delta', () => {
+    expect(formatPriceDelta(15.56)).toBe('+€15.56');
+  });
+
+  test('signs a downgrade delta', () => {
+    expect(formatPriceDelta(-15.56)).toBe('-€15.56');
+  });
+
+  test('zero counts as non-negative', () => {
+    expect(formatPriceDelta(0)).toBe('+€0.00');
+  });
+
+  test('returns dash for null', () => {
+    expect(formatPriceDelta(null)).toBe('€—');
   });
 });
 

--- a/tests/unit/pricing.spec.js
+++ b/tests/unit/pricing.spec.js
@@ -51,7 +51,6 @@ describe('formatPrice', () => {
 });
 
 describe('formatPriceDelta', () => {
-  // m + 30GB (37.34) minus s + 30GB (21.78)
   test('signs an upgrade delta', () => {
     expect(formatPriceDelta(15.56)).toBe('+€15.56');
   });

--- a/tests/unit/settings-pricing.spec.js
+++ b/tests/unit/settings-pricing.spec.js
@@ -1,0 +1,71 @@
+import Settings from '@/views/Settings.vue';
+
+// The price preview is a launch blocker (German consumer law: the price must be
+// visible before purchase), so the computed props that feed it are tested
+// directly. They are plain functions, so no mount/DOM harness is needed.
+const {billingEnabled, currentSizePrice, selectedSizePrice, priceDelta} = Settings.computed;
+
+function vm({profile, selectedSize = null}) {
+  const self = {
+    $store: {state: {profile}},
+    resize: {selectedSize},
+  };
+  // priceDelta reads the other two computed props off `this`.
+  self.currentSizePrice = currentSizePrice.call(self);
+  self.selectedSizePrice = selectedSizePrice.call(self);
+  return self;
+}
+
+const TRIAL_S = {vm_size: 's', volume_size_gb: 30, billing_enabled: true};
+
+describe('currentSizePrice', () => {
+  test('prices the current size against the shard volume', () => {
+    expect(currentSizePrice.call(vm({profile: TRIAL_S}))).toBe(21.78);
+  });
+
+  test('is null when the volume size is unknown', () => {
+    // The controller rejects subscribe with 422 in this case, so the UI must
+    // not invent a price computed against a 0GB volume.
+    expect(currentSizePrice.call(vm({profile: {vm_size: 's'}}))).toBeNull();
+  });
+
+  test('is null without a profile', () => {
+    expect(currentSizePrice.call(vm({profile: null}))).toBeNull();
+  });
+});
+
+describe('selectedSizePrice', () => {
+  test('prices the selected size, not the current one', () => {
+    const self = vm({profile: TRIAL_S, selectedSize: 'm'});
+    expect(selectedSizePrice.call(self)).toBe(37.49);
+  });
+
+  test('is null while no size is selected', () => {
+    expect(selectedSizePrice.call(vm({profile: TRIAL_S}))).toBeNull();
+  });
+});
+
+describe('priceDelta', () => {
+  test('is the increase over the current price', () => {
+    // m + 30GB (37.49) - s + 30GB (21.78)
+    expect(priceDelta.call(vm({profile: TRIAL_S, selectedSize: 'm'}))).toBe(15.71);
+  });
+
+  test('is null while no size is selected', () => {
+    expect(priceDelta.call(vm({profile: TRIAL_S}))).toBeNull();
+  });
+
+  test('is null when the volume size is unknown', () => {
+    expect(priceDelta.call(vm({profile: {vm_size: 's'}, selectedSize: 'm'}))).toBeNull();
+  });
+});
+
+describe('billingEnabled', () => {
+  test('true when the profile enables billing', () => {
+    expect(billingEnabled.call(vm({profile: TRIAL_S}))).toBe(true);
+  });
+
+  test('false without a profile', () => {
+    expect(billingEnabled.call(vm({profile: null}))).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #27.

Reworks the subscription/resize area of Settings. The subscribe-side price display is the launch blocker; the rest is the polish from the same issue.

## What changed

**1. Merged the Size and Subscription sections.** They are now one card. A resize on a subscribed shard *is* a billing change, so splitting them across two sections split one decision across two places. Size comes first, so the card reads top-to-bottom as "pick a size → see the price → subscribe". The card is titled *Size* alone when billing is disabled, and keeps the `#size` anchor that `AppIcon`/`AppStoreEntry` deep-link to.

**2. The monthly price is now shown before the buyer leaves for PayPal**, on both flows:
- **Subscribe** (trial + grace/reactivate): the current size and its monthly gross price, above the PayPal button.
- **Resize**: the new monthly price plus the delta vs. current, before confirming.

Gross incl. 19% VAT, with the VAT share broken out, matching how the active-subscription card already renders it.

**3. The PayPal revise button** now has a deliberate slot under the size buttons with a width cap, instead of popping in fluid-width alongside them.

**4. Resize approval hands off to the restart screen** rather than polling on a busy Settings page. Since resize is the only thing that routes to `/restart`, that screen now returns to `/settings` instead of the app grid.

## Two things worth knowing

**The pricing mirror is in lockstep — verified, not assumed.** The issue flagged the risk that `pricing.js` lagged controller #298 and would preview net while PayPal charges gross. It has not: `origin/main` of the controller computes `(vm + disk*0.04) * 1.5 * 1.19`, identical to `pricing.js`, and deliberately uses half-up rounding (`int(eur*100 + 0.5)`) to stay bit-identical to JS `Math.round`. No drift. (The local controller checkout was stale on an old branch and *did* show a divergent formula — worth knowing if you check this by hand.)

**A pre-existing bug was blocking resize entirely for unsubscribed shards.** e5d25e9 replaced the confirm button with the PayPal revise container, which only renders for an active subscription. That orphaned `resizeShard()` — it had zero template callers, so trial shards saw explanatory text, an empty div and a Cancel link, with no way to resize. The confirm button is restored for that path. This is why item 2's "before confirming" had nothing to attach to.

## Known issues I did not fix (your call)

- **Downsize is selectable but always fails.** `sizeIsAvailable` only excludes the *current* size, so a smaller size can be picked, while the controller rejects any non-increasing resize with 409. Pre-existing, but the new price preview makes it worse: it now advertises "New price: €21.78/month (-€15.71 vs. current)" for an operation that cannot succeed. One-line fix (upsize-only), but it changes which buttons are enabled and might pre-empt intended downsize support, so I left it.
- **A never-delivered `BILLING.SUBSCRIPTION.UPDATED` webhook now strands the user on `/restart`.** The old subscribed path polled in place and surfaced a Refresh button after 60s; the restart screen has no such escape hatch, though it does escalate to "contact support" after 50s. This is the behaviour the issue asked for and matches the unsubscribed path, so I kept it — flagging in case the failure mode matters more than the consistency.

## Verification

- `npm run test:unit` — 33 passing (14 new).
- `npm run lint`, `npm run build` — clean. Note CI only builds; it does not run the unit tests.
- The price-preview computed props are tested directly as plain functions (no mount harness — this repo has no component tests, and adding `@vue/test-utils` felt like a separate decision). I confirmed the tests have teeth by mutating `computeMonthlyPrice(p.vm_size, p.volume_size_gb)` to `|| 0` and watching the null-volume test fail.
- Not exercised against a live PayPal sandbox — the SDK paths (`createSubscription`/`onApprove`) are unchanged apart from the `/restart` handoff.

## Recommended reading order

1. `src/lib/pricing.js` — adds `formatPriceDelta`
2. `src/views/Restart.vue` — one-line return target
3. `src/views/Settings.vue` — the merged card (bulk of the diff)
4. `agents.md` — documents the price-before-PayPal rule and the mirror lockstep trap
5. `tests/unit/pricing.spec.js`, `tests/unit/settings-pricing.spec.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
