### PR TITLE
fix(justfile): refresh package-lock.json during set-version

### DIFF
--- a/justfile
+++ b/justfile
@@ -3,7 +3,8 @@ default:
 
 @set-version version:
     just _set-version-files {{version}}
-    git add .
+    npm install --package-lock-only
+    git add package.json package-lock.json
     git commit -m "set version to {{version}}"
     echo "Version set to {{version}} and committed"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-terminal",
-  "version": "0.38.1",
+  "version": "0.39.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "web-terminal",
-      "version": "0.38.1",
+      "version": "0.39.6",
       "dependencies": {
         "axios": ">=1.8.2",
         "bootstrap": "^4.5.3",


### PR DESCRIPTION
Fixes #35.

`just set-version` bumped `package.json` but never refreshed `package-lock.json`, so the lock's recorded project version drifted with every release — `main` had `package.json` at 0.39.6 while the lock still said 0.38.1. The recipe also used `git add .`, which would sweep any untracked local state into a version commit.

## Changes

- **`justfile`** — run `npm install --package-lock-only` after the `package.json` edit so the lock tracks the manifest in the same commit (rewrites the lockfile without touching `node_modules`), and replace `git add .` with the explicit path list `package.json package-lock.json`.
- **`package-lock.json`** — repair the existing drift by syncing the recorded version to 0.39.6. Generated by running the fixed recipe, not hand-edited.

Same fix pattern as shard_core: https://github.com/FreeshardBase/freeshard/pull/153

## Verification

Ran the fixed recipe end-to-end with a stray untracked file present:

- The resulting commit contained `package-lock.json` only (`package.json` was already at 0.39.6).
- The stray untracked file was left untouched, confirming `git add .` no longer sweeps local state.
- The lockfile diff is exactly the two version fields; `lockfileVersion` stays at 2 under npm 9 (no v2 → v3 upgrade churn).

Snapshot CI runs `npm install`, not `npm ci`, so the lock change carries no CI risk.

## Recommended reading order

1. `justfile` — the actual fix
2. `package-lock.json` — mechanical output of the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
