### PR TITLE
fix(pairing): show the server's error message instead of the raw AxiosError

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -38,6 +38,9 @@ src/
     Public.vue           Edit own profile (name, email, avatar)
     Peers.vue            Peer management (currently hidden)
     Restart.vue          Redirect target after shard restart
+  lib/                 Framework-free pure functions, unit-tested from tests/unit/
+    errors.js            errorMessage(): displayable string from an axios error
+    pricing.js           Shard price computation
   components/          13 reusable UI components
     Navbar.vue           Sticky nav with feedback modal, version update notification, disk warnings
     AppIcon.vue          App launcher tile with status indicator
@@ -57,6 +60,10 @@ All API calls go to the shard_core backend. Two base paths:
 - `/core/protected/*` — requires paired terminal (apps, settings, backup, etc.)
 
 Dev proxy: `vue.config.js` proxies requests to a remote shard or `localhost:8080`.
+
+Backend errors carry the reason in the response body's `detail` field. Render caught errors
+through the `errorMessage` filter (`{{ err | errorMessage }}`) rather than binding the error
+object directly — binding it directly renders `AxiosError: Received HTTP status 401`.
 
 ### Authentication Flow
 1. App loads → calls `/core/public/meta/whoami`

--- a/src/lib/errors.js
+++ b/src/lib/errors.js
@@ -1,0 +1,7 @@
+export function errorMessage(error) {
+  const data = error && error.response && error.response.data;
+  if (data) {
+    return data.detail || data.error || data.message || data;
+  }
+  return (error && error.message) || error;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,7 @@ import 'vue-tour/dist/vue-tour.css'
 import './assets/css/main.css'
 import QrcodeVue from "qrcode.vue";
 import moment from "moment/moment";
+import { errorMessage } from './lib/errors';
 
 Vue.use(BootstrapVue)
 Vue.use(BootstrapVueIcons)
@@ -38,9 +39,7 @@ Vue.filter('formatDateHumanize', function (value) {
   return duration.humanize(true);
 })
 
-Vue.filter('errorMessage', function (error) {
-  return error.response.data.detail || error.response.data.error || error.response.data.message || error.response.data || error.message || error;
-})
+Vue.filter('errorMessage', errorMessage)
 
 new Vue({
   router,

--- a/src/views/Pair.vue
+++ b/src/views/Pair.vue
@@ -35,7 +35,7 @@
           </b-form>
         </div>
 
-        <b-alert v-model="show_error" dismissible variant="danger">{{ pairing_error }}</b-alert>
+        <b-alert v-model="show_error" dismissible variant="danger">{{ pairing_error | errorMessage }}</b-alert>
 
       </b-col>
       <b-col></b-col>

--- a/src/views/Terminals.vue
+++ b/src/views/Terminals.vue
@@ -34,7 +34,7 @@
     <b-modal id="new-terminal-modal" title="Pair new terminal" hide-footer @hidden="stopPairing">
       <b-spinner v-if="pairing.loading"></b-spinner>
       <p v-else-if="pairing.error">
-        {{ pairing.error }}
+        {{ pairing.error | errorMessage }}
       </p>
       <div v-else-if="pairingCodeValidityProgress===0">
         <p>Pairing code expired</p>

--- a/tests/unit/errors.spec.js
+++ b/tests/unit/errors.spec.js
@@ -1,0 +1,28 @@
+import { errorMessage } from '@/lib/errors';
+
+describe('errorMessage', () => {
+  test('prefers the detail field of an API error response', () => {
+    const error = {
+      message: 'Request failed with status code 401',
+      response: {data: {detail: 'This pairing code has expired.'}},
+    };
+    expect(errorMessage(error)).toBe('This pairing code has expired.');
+  });
+
+  test('falls back to error/message fields of the response body', () => {
+    expect(errorMessage({response: {data: {error: 'boom'}}})).toBe('boom');
+    expect(errorMessage({response: {data: {message: 'boom'}}})).toBe('boom');
+  });
+
+  test('uses a plain-string response body as-is', () => {
+    expect(errorMessage({response: {data: 'Bad Gateway'}})).toBe('Bad Gateway');
+  });
+
+  test('falls back to the axios message when there is no response', () => {
+    expect(errorMessage({message: 'Network Error'})).toBe('Network Error');
+  });
+
+  test('handles an error with neither response nor message', () => {
+    expect(errorMessage('kaboom')).toBe('kaboom');
+  });
+});


### PR DESCRIPTION
Frontend half of FreeshardBase/freeshard#156. Pairs with FreeshardBase/freeshard#164, which makes the backend send the reason.

## Problem

`Pair.vue` and `Terminals.vue` bound the caught axios error object straight into the template, so a failed pairing rendered `AxiosError: Received HTTP status 401` — the exact symptom Stefan reported.

## Change

Both views now render through the **existing** `errorMessage` filter (`{{ err | errorMessage }}`), which already extracts `response.data.detail` and is used the same way in `Apps.vue` and `AppStoreEntry.vue`. The issue spec suggested inlining `response?.response?.data?.detail`; reusing the filter avoids a third pattern for the same job, and optional chaining is not used anywhere in this codebase (Vue 2 templates cannot compile it).

That filter dereferenced `error.response.data` unguarded, so it threw a `TypeError` on any error without a `response` — exactly the network-failure case where the user most needs a message. It is now guarded and falls back to the axios `message`. This also fixes the same latent crash for the two pre-existing call sites.

The filter moved to `src/lib/errors.js` so it can be unit-tested: `main.js` mounts the app on import, so nothing defined there is reachable from a test. `lib/` + a matching `tests/unit` spec is the existing pattern (see `lib/pricing.js`).

## Verification

```
Test Suites: 4 passed, 4 total
Tests:       24 passed, 24 total
```

`vue-cli-service lint` → no errors. `vue-cli-service build` → build complete, which is what proves the template filter compiles.

Note: `build` needs `NODE_OPTIONS=--openssl-legacy-provider` on Node 20 (webpack 4 / OpenSSL 3). Pre-existing on main, unrelated to this change, left alone.

I did not drive the real browser end-to-end. The chain is covered in pieces: the backend returns the detail (tested in freeshard#164), the filter extracts it (tested here), and the templates apply it (build compiles).

## Recommended reading order

1. `src/lib/errors.js` — extracted, now null-safe
2. `src/main.js` — filter registration
3. `src/views/Pair.vue`, `src/views/Terminals.vue` — the two render sites
4. `tests/unit/errors.spec.js`
5. `agents.md`

## Docs

`agents.md` gained the `src/lib/` entry (missing entirely, though `lib/pricing.js` predates this change) and the error-rendering convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)